### PR TITLE
Add basic phonebook Blazor skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+bin/
+obj/
+*.user
+*.suo
+*.db
+.vscode/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,51 @@
-# TB
+# Phonebook Web Application
+
+This repository contains a sample Phonebook web application built with **.NET 9**, **Blazor WebAssembly** (client) and an ASP.NET Core minimal API (server). The project demonstrates the use of Entity Framework Core with SQL Server, AutoMapper, Serilog logging, FluentValidation, and a layered architecture with repository and service patterns.
+
+## Project Structure
+
+```
+src/
+  Client/        Blazor WebAssembly client
+  Server/        ASP.NET Core server (minimal API)
+  Shared/        Shared DTOs and models
+  Infrastructure/ Data access and EF Core context
+
+tests/
+  UnitTests/     xUnit test project
+```
+
+## Prerequisites
+
+- .NET SDK 9.0 (preview)
+- SQL Server instance
+
+## Running the Application
+
+1. Ensure a SQL Server instance is running and update the connection string in `src/Server/appsettings.json`.
+2. From the repository root, restore and build the solution:
+   ```bash
+   dotnet restore
+   dotnet build
+   ```
+3. Apply EF Core migrations:
+   ```bash
+   dotnet ef database update --project src/Infrastructure --startup-project src/Server
+   ```
+4. Start the server and client:
+   ```bash
+   dotnet run --project src/Server
+   ```
+   The Blazor WebAssembly client will be served from the server.
+
+## Testing
+
+Run unit tests with:
+```bash
+ dotnet test
+```
+
+## Notes
+
+This project is provided as a starting point and may require additional configuration depending on your environment. See individual project files for more details.
+

--- a/src/Client/App.razor
+++ b/src/Client/App.razor
@@ -1,0 +1,10 @@
+<Router AppAssembly="typeof(Program).Assembly">
+    <Found Context="routeData">
+        <RouteView RouteData="routeData" DefaultLayout="typeof(MainLayout)" />
+    </Found>
+    <NotFound>
+        <LayoutView Layout="typeof(MainLayout)">
+            <p>Sorry, there's nothing at this address.</p>
+        </LayoutView>
+    </NotFound>
+</Router>

--- a/src/Client/Client.csproj
+++ b/src/Client/Client.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.0-preview.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.0-preview.1" PrivateAssets="all" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Shared/Shared.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Client/MainLayout.razor
+++ b/src/Client/MainLayout.razor
@@ -1,0 +1,13 @@
+@inherits LayoutComponentBase
+
+<div class="page">
+    <div class="sidebar">
+        <NavMenu />
+    </div>
+
+    <main>
+        <article class="content px-4">
+            @Body
+        </article>
+    </main>
+</div>

--- a/src/Client/NavMenu.razor
+++ b/src/Client/NavMenu.razor
@@ -1,0 +1,13 @@
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+    <a class="navbar-brand" href="">Phonebook</a>
+    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
+        <ul class="navbar-nav">
+            <li class="nav-item">
+                <NavLink class="nav-link" href="/">Contacts</NavLink>
+            </li>
+        </ul>
+    </div>
+</nav>

--- a/src/Client/Pages/Contacts.razor
+++ b/src/Client/Pages/Contacts.razor
@@ -1,0 +1,40 @@
+@page "/"
+@inject HttpClient Http
+
+<h3>Contacts</h3>
+
+@if (contacts == null)
+{
+    <p><em>Loading...</em></p>
+}
+else
+{
+    <table class="table">
+        <thead>
+            <tr>
+                <th>First Name</th>
+                <th>Last Name</th>
+                <th>Phone</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var contact in contacts)
+            {
+                <tr>
+                    <td>@contact.FirstName</td>
+                    <td>@contact.LastName</td>
+                    <td>@contact.PhoneNumbers.FirstOrDefault()?.Number</td>
+                </tr>
+            }
+        </tbody>
+    </table>
+}
+
+@code {
+    private List<ContactDto>? contacts;
+
+    protected override async Task OnInitializedAsync()
+    {
+        contacts = await Http.GetFromJsonAsync<List<ContactDto>>("api/contacts");
+    }
+}

--- a/src/Client/Pages/_Imports.razor
+++ b/src/Client/Pages/_Imports.razor
@@ -1,0 +1,2 @@
+@using System.Net.Http.Json
+@using Shared

--- a/src/Client/Program.cs
+++ b/src/Client/Program.cs
@@ -1,0 +1,13 @@
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+using Client;
+using Shared;
+
+var builder = WebAssemblyHostBuilder.CreateDefault(args);
+builder.RootComponents.Add<App>("#app");
+builder.RootComponents.Add<HeadOutlet>("head::after");
+
+builder.Services.AddHttpClient("ServerAPI", client => client.BaseAddress = new Uri(builder.HostEnvironment.BaseAddress));
+builder.Services.AddScoped(sp => sp.GetRequiredService<IHttpClientFactory>().CreateClient("ServerAPI"));
+
+await builder.Build().RunAsync();

--- a/src/Client/_Imports.razor
+++ b/src/Client/_Imports.razor
@@ -1,0 +1,7 @@
+@using System.Net.Http
+@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.JSInterop
+@using Client
+@using Client.Shared

--- a/src/Client/wwwroot/index.html
+++ b/src/Client/wwwroot/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phonebook</title>
+    <base href="/" />
+    <link href="css/bootstrap.min.css" rel="stylesheet" />
+</head>
+<body>
+    <div id="app">Loading...</div>
+    <script src="_framework/blazor.webassembly.js"></script>
+</body>
+</html>

--- a/src/Infrastructure/ApplicationDbContext.cs
+++ b/src/Infrastructure/ApplicationDbContext.cs
@@ -1,0 +1,13 @@
+using Microsoft.EntityFrameworkCore;
+using Shared;
+
+namespace Infrastructure;
+
+public class ApplicationDbContext : DbContext
+{
+    public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<Contact> Contacts => Set<Contact>();
+}

--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Shared/Shared.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0-preview.1" />
+  </ItemGroup>
+</Project>

--- a/src/Infrastructure/Repositories/ContactRepository.cs
+++ b/src/Infrastructure/Repositories/ContactRepository.cs
@@ -1,0 +1,36 @@
+using Microsoft.EntityFrameworkCore;
+using Shared;
+
+namespace Infrastructure.Repositories;
+
+public class ContactRepository : IContactRepository
+{
+    private readonly ApplicationDbContext _context;
+
+    public ContactRepository(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<IEnumerable<Contact>> GetAllAsync() => await _context.Contacts.ToListAsync();
+
+    public async Task<Contact?> GetByIdAsync(int id) => await _context.Contacts.FindAsync(id);
+
+    public async Task AddAsync(Contact contact)
+    {
+        _context.Contacts.Add(contact);
+        await _context.SaveChangesAsync();
+    }
+
+    public async Task UpdateAsync(Contact contact)
+    {
+        _context.Contacts.Update(contact);
+        await _context.SaveChangesAsync();
+    }
+
+    public async Task DeleteAsync(Contact contact)
+    {
+        _context.Contacts.Remove(contact);
+        await _context.SaveChangesAsync();
+    }
+}

--- a/src/Infrastructure/Repositories/IContactRepository.cs
+++ b/src/Infrastructure/Repositories/IContactRepository.cs
@@ -1,0 +1,14 @@
+using Shared;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Infrastructure.Repositories;
+
+public interface IContactRepository
+{
+    Task<IEnumerable<Contact>> GetAllAsync();
+    Task<Contact?> GetByIdAsync(int id);
+    Task AddAsync(Contact contact);
+    Task UpdateAsync(Contact contact);
+    Task DeleteAsync(Contact contact);
+}

--- a/src/Server/Program.cs
+++ b/src/Server/Program.cs
@@ -1,0 +1,49 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Serilog;
+using FluentValidation.AspNetCore;
+using Infrastructure;
+using Infrastructure.Repositories;
+using Server.Services;
+using AutoMapper;
+using Shared;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Serilog configuration
+builder.Host.UseSerilog((ctx, cfg) => cfg.ReadFrom.Configuration(ctx.Configuration));
+
+builder.Services.AddDbContext<ApplicationDbContext>(options =>
+    options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
+
+builder.Services.AddAutoMapper(typeof(MappingProfile));
+builder.Services.AddFluentValidationAutoValidation();
+
+builder.Services.AddScoped<IContactRepository, ContactRepository>();
+builder.Services.AddScoped<IContactService, ContactService>();
+
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+
+var contacts = app.MapGroup("/api/contacts");
+
+contacts.MapGet("/", (IContactService service) => service.GetContactsAsync());
+contacts.MapGet("/{id:int}", (int id, IContactService service) => service.GetByIdAsync(id));
+contacts.MapPost("/", (ContactDto dto, IContactService service) => service.CreateAsync(dto));
+contacts.MapPut("/{id:int}", (int id, ContactDto dto, IContactService service) => service.UpdateAsync(id, dto));
+contacts.MapDelete("/{id:int}", (int id, IContactService service) => service.DeleteAsync(id));
+
+app.Run();
+

--- a/src/Server/Server.csproj
+++ b/src/Server/Server.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Shared/Shared.csproj" />
+    <ProjectReference Include="../Infrastructure/Infrastructure.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0-preview.1" />
+    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
+    <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
+    <PackageReference Include="FluentValidation.AspNetCore" Version="12.1.0" />
+  </ItemGroup>
+</Project>

--- a/src/Server/Services/ContactService.cs
+++ b/src/Server/Services/ContactService.cs
@@ -1,0 +1,53 @@
+using AutoMapper;
+using Infrastructure.Repositories;
+using Shared;
+
+namespace Server.Services;
+
+public class ContactService : IContactService
+{
+    private readonly IContactRepository _repo;
+    private readonly IMapper _mapper;
+
+    public ContactService(IContactRepository repo, IMapper mapper)
+    {
+        _repo = repo;
+        _mapper = mapper;
+    }
+
+    public async Task<ContactDto> CreateAsync(ContactDto dto)
+    {
+        var contact = _mapper.Map<Contact>(dto);
+        await _repo.AddAsync(contact);
+        return _mapper.Map<ContactDto>(contact);
+    }
+
+    public async Task<bool> DeleteAsync(int id)
+    {
+        var contact = await _repo.GetByIdAsync(id);
+        if (contact == null) return false;
+        await _repo.DeleteAsync(contact);
+        return true;
+    }
+
+    public async Task<ContactDto?> GetByIdAsync(int id)
+    {
+        var contact = await _repo.GetByIdAsync(id);
+        return contact == null ? null : _mapper.Map<ContactDto>(contact);
+    }
+
+    public async Task<IEnumerable<ContactDto>> GetContactsAsync()
+    {
+        var contacts = await _repo.GetAllAsync();
+        return contacts.Select(c => _mapper.Map<ContactDto>(c));
+    }
+
+    public async Task<ContactDto?> UpdateAsync(int id, ContactDto dto)
+    {
+        var contact = await _repo.GetByIdAsync(id);
+        if (contact == null) return null;
+        _mapper.Map(dto, contact);
+        await _repo.UpdateAsync(contact);
+        return _mapper.Map<ContactDto>(contact);
+    }
+}

--- a/src/Server/Services/IContactService.cs
+++ b/src/Server/Services/IContactService.cs
@@ -1,0 +1,14 @@
+using Shared;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Server.Services;
+
+public interface IContactService
+{
+    Task<IEnumerable<ContactDto>> GetContactsAsync();
+    Task<ContactDto?> GetByIdAsync(int id);
+    Task<ContactDto> CreateAsync(ContactDto dto);
+    Task<ContactDto?> UpdateAsync(int id, ContactDto dto);
+    Task<bool> DeleteAsync(int id);
+}

--- a/src/Server/appsettings.json
+++ b/src/Server/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=PhonebookDb;Trusted_Connection=True;MultipleActiveResultSets=true"
+  },
+  "Serilog": {
+    "MinimumLevel": "Information",
+    "WriteTo": [ { "Name": "Console" } ]
+  }
+}

--- a/src/Shared/DTOs/ContactDto.cs
+++ b/src/Shared/DTOs/ContactDto.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace Shared;
+
+public class ContactDto
+{
+    public int Id { get; set; }
+    [Required]
+    public string FirstName { get; set; } = string.Empty;
+    [Required]
+    public string LastName { get; set; } = string.Empty;
+    [EmailAddress]
+    public string? Email { get; set; }
+    public string? Company { get; set; }
+    public string? Address { get; set; }
+    public string? Notes { get; set; }
+    public string? Group { get; set; }
+    public List<PhoneNumberDto> PhoneNumbers { get; set; } = new();
+}
+
+public class PhoneNumberDto
+{
+    public int Id { get; set; }
+    [Required]
+    public string Number { get; set; } = string.Empty;
+    public string? Type { get; set; }
+}

--- a/src/Shared/MappingProfile.cs
+++ b/src/Shared/MappingProfile.cs
@@ -1,0 +1,12 @@
+using AutoMapper;
+
+namespace Shared;
+
+public class MappingProfile : Profile
+{
+    public MappingProfile()
+    {
+        CreateMap<Contact, ContactDto>().ReverseMap();
+        CreateMap<PhoneNumber, PhoneNumberDto>().ReverseMap();
+    }
+}

--- a/src/Shared/Models/Contact.cs
+++ b/src/Shared/Models/Contact.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace Shared;
+
+public class Contact
+{
+    public int Id { get; set; }
+    [Required]
+    public string FirstName { get; set; } = string.Empty;
+    [Required]
+    public string LastName { get; set; } = string.Empty;
+    [EmailAddress]
+    public string? Email { get; set; }
+    public string? Company { get; set; }
+    public string? Address { get; set; }
+    public string? Notes { get; set; }
+    public string? Group { get; set; }
+    public List<PhoneNumber> PhoneNumbers { get; set; } = new();
+}
+
+public class PhoneNumber
+{
+    public int Id { get; set; }
+    [Required]
+    public string Number { get; set; } = string.Empty;
+    public string? Type { get; set; }
+}

--- a/src/Shared/Shared.csproj
+++ b/src/Shared/Shared.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="AutoMapper" Version="12.0.1" />
+    <PackageReference Include="FluentValidation" Version="12.1.0" />
+  </ItemGroup>
+</Project>

--- a/src/Shared/Validators/ContactDtoValidator.cs
+++ b/src/Shared/Validators/ContactDtoValidator.cs
@@ -1,0 +1,21 @@
+using FluentValidation;
+
+namespace Shared;
+
+public class ContactDtoValidator : AbstractValidator<ContactDto>
+{
+    public ContactDtoValidator()
+    {
+        RuleFor(x => x.FirstName).NotEmpty();
+        RuleFor(x => x.LastName).NotEmpty();
+        RuleForEach(x => x.PhoneNumbers).SetValidator(new PhoneNumberDtoValidator());
+    }
+}
+
+public class PhoneNumberDtoValidator : AbstractValidator<PhoneNumberDto>
+{
+    public PhoneNumberDtoValidator()
+    {
+        RuleFor(x => x.Number).NotEmpty();
+    }
+}

--- a/tests/UnitTests/ContactServiceTests.cs
+++ b/tests/UnitTests/ContactServiceTests.cs
@@ -1,0 +1,24 @@
+using Xunit;
+using System.Collections.Generic;
+using Moq;
+using Server.Services;
+using Infrastructure.Repositories;
+using Shared;
+
+namespace UnitTests;
+
+public class ContactServiceTests
+{
+    [Fact]
+    public async Task GetContacts_Returns_List()
+    {
+        var repo = new Mock<IContactRepository>();
+        repo.Setup(r => r.GetAllAsync()).ReturnsAsync(new List<Contact>());
+        var mapper = new AutoMapper.Mapper(new AutoMapper.MapperConfiguration(cfg => cfg.AddProfile<MappingProfile>()));
+        var service = new ContactService(repo.Object, mapper);
+
+        var result = await service.GetContactsAsync();
+
+        Assert.NotNull(result);
+    }
+}

--- a/tests/UnitTests/UnitTests.csproj
+++ b/tests/UnitTests/UnitTests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="Moq" Version="4.18.4" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/Server/Server.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- set up project layout for Blazor WebAssembly client and ASP.NET Core Minimal API server
- add EF Core infrastructure with repository pattern
- add service layer with AutoMapper and FluentValidation
- add minimal Blazor UI and sample unit test
- document build and run instructions

## Testing
- `dotnet test` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fc6aeceec83298a9f9db52d2c2464